### PR TITLE
Event module updates

### DIFF
--- a/control/event.lua
+++ b/control/event.lua
@@ -529,12 +529,35 @@ event.conditional_event_groups = conditional_event_groups
 return event
 
 ---@section Concepts
--- TODO: How to document!? It should match the contents of https://github.com/raiguard/Factorio-RaiLuaLib/wiki/Event#concepts
+-- TODO: Fix documentation style if needed
 
+--- One of the following:
+-- - A member of [defines.events](https://lua-api.factorio.com/latest/defines.html#defines.events).
+-- - A [string](https://lua-api.factorio.com/latest/builtin-types.html#string) corresponding to a `custom-input` prototype name, or a bootstrap event.
+-- - A negative [int](https://lua-api.factorio.com/latest/builtin-types.html#int) corresponding to an `nth_tick` value.
+-- - A positive [int](https://lua-api.factorio.com/latest/builtin-types.html#int) corresponding to a custom mod-generated event.
+-- **Examples**
+-- `defines.events.on_player_created`
+-- `'rll-open-search'`
+-- `' on_init'`
+-- `-25`
+-- `241`
 ---@class EventId
 
+
+--- Table with the following fields:
+-- - skip_validation :: [boolean](https://lua-api.factorio.com/latest/Builtin-Types.html#boolean) (optional): If true, validation of userdata will be skipped when the event is raised. This saves on performance, but doesn't protect against crashes relating to invalid userdata!
+-- - insert_at :: [int](https://lua-api.factorio.com/latest/Builtin-Types.html#int) (optional): Inserts the handler at the given position in the event table, instead of at the back.
+-- **Examples**
+-- `{skip_validation=true, insert_at=1}`
 ---@class EventOptions
 
+--- Dictionary [string](https://lua-api.factorio.com/latest/Builtin-Types.html#string) -> [table](https://lua-api.factorio.com/latest/Builtin-Types.html#table). Each table of this dictionary has the following fields:
+-- - id :: [EventId](#eventid) or array of [EventId](#eventid): The event ID(s) to invoke the handler on.
+-- - handler :: function(event): The handler to run. Receives an event table [as defined in the Factorio documentation](https://lua-api.factorio.com/latest/events.html).
+-- - group :: [string](https://lua-api.factorio.com/latest/Builtin-Types.html#string) or array of [string](https://lua-api.factorio.com/latest/Builtin-Types.html#string) (optional): Assigns this event to one or more groups.
+-- - gui_filters :: [GuiFilter](#guifilter) or array of [GuiFilter](#guifilter) (optional): Static GUI filters to use for this event.
+-- - options :: [EventOptions](#eventoptions) (optional): Additional options.
 ---@class ConditionalEvents
 
 ---@class EventFilters https://lua-api.factorio.com/latest/Event-Filters.html

--- a/control/event.lua
+++ b/control/event.lua
@@ -74,11 +74,11 @@ local function dispatch_event(e)
     end
 
     if call_handler then
-      t.handler(e)
-    end
-
-    if options.force_crc then
-      game.force_crc()
+      -- check matcher, if one exists
+      local matcher = options.matcher
+      if not matcher or matcher(e) then
+        t.handler(e)
+      end
     end
   end
   return

--- a/control/event.lua
+++ b/control/event.lua
@@ -325,6 +325,7 @@ function event.disable(name, player_index)
     end
     global_data.conditional_events[name] = nil
   end
+
   -- deregister handler
   local id = data.id
   if type(id) ~= "table" then id = {id} end
@@ -412,7 +413,7 @@ function event.on_nth_tick(nth_tick, handler, options)
   return event.register(-nth_tick, handler, nil, options)
 end
 
--- How to document!?
+-- TODO How to document!?
 for n,id in pairs(defines.events) do
   event[n] = function(handler, options)
     event.register(id, handler, options)
@@ -481,8 +482,6 @@ function event.save_id(name, id)
   end
   custom_id_registry[name] = id
 end
-
--- -----------------------------------------------------------------------------
 
 event.events = events
 event.conditional_events = conditional_events

--- a/control/event.lua
+++ b/control/event.lua
@@ -485,14 +485,8 @@ event.conditional_event_groups = conditional_event_groups
 return event
 
 ---@section Concepts
+-- TODO Learn how to do this section. It should match the contents of https://github.com/raiguard/Factorio-RaiLuaLib/wiki/Event#concepts
 
---- One of the following:
--- <ul>
---  <li></li>
---  <li></li>
---  <li></li>
---  <li></li>
--- </ul>
 ---@class EventId
 
 ---@class EventOptions

--- a/control/event.lua
+++ b/control/event.lua
@@ -2,8 +2,6 @@
 ---@usage local event = require("__flib__.control.event")
 local event = {}
 
-local migration = require("__flib__.control.migration")
-
 local math_min = math.min
 local table_insert = table.insert
 local table_remove = table.remove
@@ -387,23 +385,20 @@ end
 
 --- Shortcut for `event.register("on_init", ...)
 ---@param handler function
----@param options EventOptions
-function event.on_init(handler, options)
-  return event.register("on_init", handler, nil, options)
+function event.on_init(handler)
+  return event.register("on_init", handler)
 end
 
 --- Shortcut for `event.register("on_load", ...)
 ---@param handler function
----@param options EventOptions
-function event.on_load(handler, options)
-  return event.register("on_load", handler, nil, options)
+function event.on_load(handler)
+  return event.register("on_load", handler)
 end
 
 --- Shortcut for `event.register("on_configuration_changed", ...)
 ---@param handler function
----@param options EventOptions
-function event.on_configuration_changed(handler, options)
-  return event.register("on_configuration_changed", handler, nil, options)
+function event.on_configuration_changed(handler)
+  return event.register("on_configuration_changed", handler)
 end
 
 --- Shortcut for `event.register(-nth_tick, ...)
@@ -411,7 +406,7 @@ end
 ---@param handler function
 ---@param options EventOptions
 function event.on_nth_tick(nth_tick, handler, options)
-  return event.register(-nth_tick, handler, nil, options)
+  return event.register(-nth_tick, handler, options)
 end
 
 -- TODO How to document!?

--- a/control/event.lua
+++ b/control/event.lua
@@ -121,8 +121,8 @@ script.on_load(function()
     if data then
       event.register(data.id, data.handler, data.options, name)
     else
-      log("Conditional event ["..name.."] was enabled on save, but now has no registration data and was not re-enabled. If the name was changed, it must "
-        .."be re-enabled in on_configuration_changed. If it was removed entirely, its global data must be removed in on_configuration_changed.")
+      log("Conditional event ["..name.."] was enabled on save, but now has no registration data and was not re-enabled. If the name was changed, the event "
+        .." must be re-enabled in on_configuration_changed. If it was removed entirely, its global data must be removed in on_configuration_changed.")
     end
   end
 end)

--- a/control/event.lua
+++ b/control/event.lua
@@ -121,8 +121,11 @@ script.on_load(function()
     if data then
       event.register(data.id, data.handler, data.options, name)
     else
-      log("Conditional event ["..name.."] was enabled on save, but now has no registration data and was not re-enabled. If the name was changed, the event "
-        .." must be re-enabled in on_configuration_changed. If it was removed entirely, its global data must be removed in on_configuration_changed.")
+      log(
+        "Conditional event ["..name.."] was enabled on save, but now has no registration data and was not re-enabled."
+          .." If the name was changed, the event must be re-enabled in on_configuration_changed. If it was removed"
+          .." entirely, its global data must be removed in on_configuration_changed."
+      )
     end
   end
 end)
@@ -137,6 +140,8 @@ end)
 ---@section Registration
 
 --- Register a static (non-conditional) handler.
+-- If you're only registering an handler to a single event, and if that event is in @{defines.events} or is a bootstrap
+-- event, you can replace `event.register(id, handler, options)` with `event.event_name(handler, options)`.
 ---@param id EventId|EventId[]
 ---@param handler function
 ---@param options EventOptions
@@ -149,6 +154,9 @@ end)
 -- -- Custom inputs and bootstrap events
 -- event.register("mmd-open-gui", handler)
 -- event.register("on_configuration_changed", handler)
+-- -- Syntax shortcuts for bootstrap and defines.events
+-- event.on_configuration_changed(handler)
+-- event.on_tick(handler)
 function event.register(id, handler, options, conditional_name)
   options = options or {}
   if type(id) ~= "table" then id = {id} end
@@ -328,7 +336,7 @@ function event.disable(name, player_index)
       end
     else
       if not data.options.suppress_logging then
-        log("Tried to disable conditional event ["..name.."] from player "..player_index.." when it wasn't enabled for them!")
+        log("Tried to disable conditional event ["..name.."] from player ["..player_index.."] when it wasn't enabled for them!")
       end
       return
     end
@@ -415,20 +423,19 @@ function event.disable_group(group, player_index)
   end
 end
 
----@section Shortcut functions
-
--- TODO: how to document!?
-
+-- documented in event.register
 function event.on_nth_tick(nth_tick, handler, options)
   return event.register(-nth_tick, handler, options)
 end
 
+-- documented in event.register
 for n,_ in pairs(bootstrap_events) do
   event[n] = function(handler)
     event.register(n, handler)
   end
 end
 
+-- documented in event.register
 for n,id in pairs(defines.events) do
   event[n] = function(handler, options)
     event.register(id, handler, options)
@@ -531,34 +538,30 @@ return event
 ---@section Concepts
 -- TODO: Fix documentation style if needed
 
---- One of the following:
--- - A member of [defines.events](https://lua-api.factorio.com/latest/defines.html#defines.events).
--- - A [string](https://lua-api.factorio.com/latest/builtin-types.html#string) corresponding to a `custom-input` prototype name, or a bootstrap event.
--- - A negative [int](https://lua-api.factorio.com/latest/builtin-types.html#int) corresponding to an `nth_tick` value.
--- - A positive [int](https://lua-api.factorio.com/latest/builtin-types.html#int) corresponding to a custom mod-generated event.
+---@alias EventId defines.events|string|int
+-- One of the following:
+-- - A member of @{defines.events}.
+-- - A @{string} corresponding to a `custom-input` prototype name, or a bootstrap event.
+-- - A negative @{int} corresponding to an `nth_tick` value.
+-- - A positive @{int} corresponding to a custom mod-generated event.
 -- **Examples**
 -- `defines.events.on_player_created`
 -- `'rll-open-search'`
 -- `' on_init'`
 -- `-25`
 -- `241`
----@class EventId
 
+---@tfield[opt] boolean skip_validation Disables userdata validation. Saves on performance, but can cause crashes if not
+-- handled properly.
+---@tfield[opt] integer insert_at Inserts the handler at the given position in the event table, instead of at the back.
+---@table EventOptions
 
---- Table with the following fields:
--- - skip_validation :: [boolean](https://lua-api.factorio.com/latest/Builtin-Types.html#boolean) (optional): If true, validation of userdata will be skipped when the event is raised. This saves on performance, but doesn't protect against crashes relating to invalid userdata!
--- - insert_at :: [int](https://lua-api.factorio.com/latest/Builtin-Types.html#int) (optional): Inserts the handler at the given position in the event table, instead of at the back.
--- **Examples**
--- `{skip_validation=true, insert_at=1}`
----@class EventOptions
-
---- Dictionary [string](https://lua-api.factorio.com/latest/Builtin-Types.html#string) -> [table](https://lua-api.factorio.com/latest/Builtin-Types.html#table). Each table of this dictionary has the following fields:
--- - id :: [EventId](#eventid) or array of [EventId](#eventid): The event ID(s) to invoke the handler on.
--- - handler :: function(event): The handler to run. Receives an event table [as defined in the Factorio documentation](https://lua-api.factorio.com/latest/events.html).
--- - group :: [string](https://lua-api.factorio.com/latest/Builtin-Types.html#string) or array of [string](https://lua-api.factorio.com/latest/Builtin-Types.html#string) (optional): Assigns this event to one or more groups.
--- - gui_filters :: [GuiFilter](#guifilter) or array of [GuiFilter](#guifilter) (optional): Static GUI filters to use for this event.
--- - options :: [EventOptions](#eventoptions) (optional): Additional options.
----@class ConditionalEvents
+--- Dictionary @{string} -> @{table}. Each table of this dictionary has the following fields:
+---@field id EventId|EventId[] The event ID(s) to invoke the handler on.
+---@field handler function The handler to run. Receives an event table as defined in the Factorio documentation.
+---@field[opt] group string|string[] Assigns this event to one or more groups.
+---@field[opt] options EventOptions Additional options.
+---@table ConditionalEvents
 
 ---@class EventFilters https://lua-api.factorio.com/latest/Event-Filters.html
 ---@class EventData https://lua-api.factorio.com/latest/events.html

--- a/control/event.lua
+++ b/control/event.lua
@@ -89,7 +89,6 @@ end
 
 script.on_init(function()
   global.__flib = {
-    __version = script.active_mods["flib"], -- current version
     event = {conditional_events={}, players={}}
   }
   -- dispatch events
@@ -121,16 +120,14 @@ end)
 script.on_configuration_changed(function(e)
   -- module migrations
   if script.active_mods["flib"] ~= global.__flib.__version then
-    migration.run(global.__flib.__version, {
-      -- insert migrations here
+    migration.on_config_changed(e, {
+      -- insert migrations here if needed
     })
   end
   -- dispatch events
   for _,t in ipairs(events.on_configuration_changed or {}) do
     t.handler(e)
   end
-  -- update lualib version
-  global.__flib.__version = script.active_mods["flib"]
 end)
 
 ---@section Registration

--- a/control/event.lua
+++ b/control/event.lua
@@ -13,6 +13,9 @@ local conditional_events = {}
 -- conditional events by group
 local conditional_event_groups = {}
 
+-- bootstrap events do not go through dispatch_event, and have extra functionality
+local bootstrap_events = {on_init=true, on_init_postprocess=true, on_load=true, on_load_postprocess=true, on_configuration_changed=true}
+
 -- calls handler functions tied to an event
 -- all non-bootstrap events go through this function
 local function dispatch_event(e)
@@ -132,8 +135,6 @@ script.on_configuration_changed(function(e)
 end)
 
 ---@section Registration
-
-local bootstrap_events = {on_init=true, on_init_postprocess=true, on_load=true, on_load_postprocess=true, on_configuration_changed=true}
 
 --- Register a static (non-conditional) handler.
 ---@param id EventId|EventId[]
@@ -418,20 +419,14 @@ end
 
 -- TODO: how to document!?
 
-function event.on_init(handler)
-  return event.register("on_init", handler)
-end
-
-function event.on_load(handler)
-  return event.register("on_load", handler)
-end
-
-function event.on_configuration_changed(handler)
-  return event.register("on_configuration_changed", handler)
-end
-
 function event.on_nth_tick(nth_tick, handler, options)
   return event.register(-nth_tick, handler, options)
+end
+
+for n,_ in pairs(bootstrap_events) do
+  event[n] = function(handler)
+    event.register(n, handler)
+  end
 end
 
 for n,id in pairs(defines.events) do

--- a/control/event.lua
+++ b/control/event.lua
@@ -356,7 +356,7 @@ function event.disable(name, player_index)
     local registry = events[n]
     -- error checking
     if not registry or #registry == 0 then
-      log("Tried to deregister an unregistered event of id: "..n)
+      log("Tried to deregister an unregistered event of id ["..n.."]")
       return
     end
     for i,t in ipairs(registry) do

--- a/control/event.lua
+++ b/control/event.lua
@@ -119,11 +119,9 @@ end)
 
 script.on_configuration_changed(function(e)
   -- module migrations
-  if script.active_mods["flib"] ~= global.__flib.__version then
-    migration.on_config_changed(e, {
-      -- insert migrations here if needed
-    })
-  end
+  migration.on_config_changed(e, {
+    -- insert migrations here if needed
+  })
   -- dispatch events
   for _,t in ipairs(events.on_configuration_changed or {}) do
     t.handler(e)

--- a/control/event.lua
+++ b/control/event.lua
@@ -14,7 +14,13 @@ local conditional_events = {}
 local conditional_event_groups = {}
 
 -- bootstrap events do not go through dispatch_event, and have extra functionality
-local bootstrap_events = {on_init=true, on_init_postprocess=true, on_load=true, on_load_postprocess=true, on_configuration_changed=true}
+local bootstrap_events = {
+  on_init = true,
+  on_init_postprocess = true,
+  on_load = true,
+  on_load_postprocess = true,
+  on_configuration_changed = true
+}
 
 -- calls handler functions tied to an event
 -- all non-bootstrap events go through this function
@@ -259,7 +265,7 @@ function event.enable(name, player_index)
       if player_lookup and player_lookup[name] then
         -- don't do anything
         if not data.options.suppress_logging then
-          log("Tried to re-register conditional event ["..name.."] for player "..player_index..", skipping!")
+          log("Tried to re-register conditional event ["..name.."] for player ["..player_index.."], skipping!")
         end
         return
       else


### PR DESCRIPTION
There are several changes and improvements to the event module. I think it's a good idea for all of us to do everything through PRs so we can review each other's code and make sure it meets quality standards, among other things.

I thoroughly tested the module using a test script that I built in my Sandbox mod. It passes heavy mode checks and doesn't desync in multiplayer. Everything behaves properly so far as I can tell.

Here are the major changes versus the version on master:

### Handler raising behavioral change
The previous version of the event module would fire the handler once, then skip to the next handler. Now, if several conditional events meet the requirements for execution, it will do all of them. This means that a handler registered to two conditional events will fire twice, give that the right conditions are met.

This will allow my GUI module to work by reading GUI filters for every event, instead of getting stuck after the first one.

### Conditional name passed in the event table
A conditional handler's event name will be passed in the event table when it is dispatched. This (again) is for my GUI module to be able to match the correct filters, but can be used elsewhere as well. For example, the same handler could be registered to two conditional events, and can take slightly different actions depending on which one was raised.

### Removed __version and event module migrations
The event module would store a `__version` key inside of `global.__flib` to use during migrations. I realized that this is no longer needed, as that is a relic from when my lualib was something I copied in between mods. One can simply use the version changes given on `on_configuration_changed` for migrations.

The other change is to remove the code that would have done migrations on event data. This is unused at the moment, and can be re-added back in if migrations ever need to be done (which hopefully they won't).

### General code improvements
I refactored the `dispatch_event` and `event.raise` functions to have better quality and faster execution time. For example, `dispatch_event` no longer uses a `goto` to break execution order. I also cleaned up some redundant `if` statements.

### Documentation
Most of the functions in the module are now documented, with usage examples for each. There are two places where the documentation needs work:

#### Shortcut functions
All but one of the shortcut functions are generated dynamically, and I have no idea how to document that in LDoc:

```lua
---@section Shortcut functions

-- TODO: how to document!?

function event.on_nth_tick(nth_tick, handler, options)
  return event.register(-nth_tick, handler, options)
end

for n,_ in pairs(bootstrap_events) do
  event[n] = function(handler)
    event.register(n, handler)
  end
end

for n,id in pairs(defines.events) do
  event[n] = function(handler, options)
    event.register(id, handler, options)
  end
end
```

#### Concepts
There are several "concepts" that the event module uses, and I am unsure on the formatting for documenting them. For now I copy/pasted the explanations verbatim from my [RaiLuaLib](https://github.com/raiguard/Factorio-RaiLuaLib/wiki/Event) documentation, but it exceeds the line count and is formatted in Markdown. I am unsure of how to proceed here. These are located at the bottom of the file.