### PR TITLE
Table module

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -4,7 +4,7 @@
 -- @usage local gui = require("__flib__.gui")
 local flib_gui = {}
 
-local util = require("__core__.lualib.util")
+local table = require("__flib__.table")
 
 local string_gmatch = string.gmatch
 local string_gsub = string.gsub
@@ -19,7 +19,7 @@ local handler_groups = {}
 
 local function generate_template_lookup(t, template_string)
   for k, v in pairs(t) do
-    if k ~= "extend" and type(v) == "table" then
+    if type(v) == "table" then
       local new_string = template_string..k
       if v.type or v.template then
         template_lookup[new_string] = v
@@ -45,7 +45,7 @@ local function generate_handler_lookup(t, event_string, groups)
       if v.handler then
         v.id = v.id or defines.events[k] or k
         v.filters = {}
-        v.groups = table.deepcopy(groups)
+        v.groups = table.deep_copy(groups)
         handler_lookup[new_string] = v
         -- assign handler to groups
         for i=1,#groups do
@@ -173,22 +173,6 @@ function flib_gui.register_handlers()
   end
 end
 
--- merge tables
-local function extend_table(self, t, do_return)
-  for k, v in pairs(t) do
-    if (type(v) == "table") then
-      if (type(self[k] or false) == "table") then
-        self[k] = extend_table(self[k], v, true)
-      else
-        self[k] = table.deepcopy(v)
-      end
-    else
-      self[k] = v
-    end
-  end
-  if do_return then return self end
-end
-
 --- Add content to the @{gui.templates} table.
 -- The table you provide will be merged with the current contents of the table.
 --
@@ -199,7 +183,9 @@ end
 -- @tparam table input
 -- @see gui.templates
 function flib_gui.add_templates(input)
-  extend_table(templates, input)
+  templates = table.deep_merge{templates, input}
+  -- because the reference is lost...
+  flib_gui.templates = templates
 end
 
 --- Add content to the @{gui.handlers} table.
@@ -209,7 +195,9 @@ end
 -- @tparam table input
 -- @see gui.handlers
 function flib_gui.add_handlers(input)
-  extend_table(handlers, input)
+  handlers = table.deep_merge{handlers, input}
+  -- because the reference is lost...
+  flib_gui.handlers = handlers
 end
 
 --- Functions

--- a/table.lua
+++ b/table.lua
@@ -2,6 +2,10 @@
 --
 -- Extends the [Lua 5.2 table library](https://www.lua.org/manual/5.2/manual.html#6.5). As such, all functions available
 -- there are also available here.
+--
+-- **NOTE:** Several functions in this module will only work with [arrays](https://www.lua.org/pil/11.1.html), which are
+-- tables with sequentially numbered keys. All table functions will work with arrays as well, but array functions
+-- **will not** work with tables.
 -- @module table
 -- @alias flib_table
 -- @usage local table = require('__flib__.table')
@@ -251,5 +255,60 @@ end
 -- @tparam table tbl
 -- @treturn uint Size of the table.
 flib_table.size = table_size
+
+--- Retrieve a shallow copy of a portion of an array, selected from `start` to `end` inclusive.
+--
+-- The original array **will not** be modified.
+-- @tparam array arr
+-- @tparam[opt=1] int start
+-- @tparam[opt=#arr] int stop Stop at this index. If negative, will stop `n` items from the end of the array.
+-- @treturn array A new array with the copied values.
+function flib_table.slice(arr, start, stop)
+  local output = {}
+  local n = #arr
+
+  start = start or 1
+  stop = stop or n
+  stop = stop < 0 and (n + stop + 1) or stop
+
+  if start < 1 or start > n then
+    return {}
+  end
+
+  local k = 1
+  for i = start, stop do
+    output[k] = arr[i]
+    k = k + 1
+  end
+  return output
+end
+
+--- Extract a portion of an array, selected from `start` to `end` inclusive.
+--
+-- The original array **will** be modified.
+-- @tparam array arr
+-- @tparam[opt=1] int start
+-- @tparam[opt=#arr] int stop Stop at this index. If negative, will stop `n` items from the end of the array.
+-- @treturn array A new array with the extracted values.
+function flib_table.splice(arr, start, stop)
+  local output = {}
+  local n = #arr
+
+  start = start or 1
+  stop = stop or n
+  stop = stop < 0 and (n + stop + 1) or stop
+
+  if start < 1 or start > n then
+    return {}
+  end
+
+  local k = 1
+  for _ = start, stop do
+    output[k] = arr[start]
+    table.remove(arr, start)
+    k = k + 1
+  end
+  return output
+end
 
 return flib_table

--- a/table.lua
+++ b/table.lua
@@ -77,9 +77,9 @@ function flib_table.deep_merge(tables)
     for k, v in pairs(tbl) do
       if type(v) == "table" then
         if type(output[k] or false) == "table" then
-          output[k] = flib_table.merge{output[k], v}
+          output[k] = flib_table.deep_merge{output[k], v}
         else
-          output[k] = table.deepcopy(v)
+          output[k] = flib_table.deep_copy(v)
         end
       else
         output[k] = v

--- a/table.lua
+++ b/table.lua
@@ -172,8 +172,8 @@ end
 -- `filter` returned a truthy value.
 -- @tparam table tbl
 -- @tparam function filter Takes in `value` and `key` as parameters.
--- @tparam[opt] boolean If true, the result will be constructed as an array of values that matched the filter. Key
--- references will be lost.
+-- @tparam[opt] boolean array_insert If true, the result will be constructed as an array of values that matched the
+-- filter. Key references will be lost.
 -- @treturn table A new table containing only the filtered values.
 function flib_table.filter(tbl, filter, array_insert)
   local output = {}

--- a/table.lua
+++ b/table.lua
@@ -22,14 +22,14 @@ end
 -- @treturn boolean If the tables are the same.
 function flib_table.deep_compare(tbl1, tbl2)
   if tbl1 == tbl2 then return true end
-  for k, v in pairs( tbl1 ) do
+  for k, v in pairs(tbl1) do
     if  type(v) == "table" and type(tbl2[k]) == "table" then
       if not flib_table.deep_compare( v, tbl2[k] )  then return false end
     else
-      if ( v ~= tbl2[k] ) then return false end
+      if v ~= tbl2[k] then return false end
     end
   end
-  for k, v in pairs( tbl2 ) do
+  for k in pairs(tbl2) do
     if tbl1[k] == nil then return false end
   end
   return true
@@ -75,8 +75,8 @@ function flib_table.deep_merge(tables)
   local output = {}
   for _, tbl in ipairs(tables) do
     for k, v in pairs(tbl) do
-      if (type(v) == "table") then
-        if (type(output[k] or false) == "table") then
+      if type(v) == "table" then
+        if type(output[k] or false) == "table" then
           output[k] = flib_table.merge{output[k], v}
         else
           output[k] = table.deepcopy(v)

--- a/table.lua
+++ b/table.lua
@@ -150,12 +150,12 @@ function flib_table.for_n_of(tbl, from_k, n, callback, _next)
     end
 
     if v then
-      result[from_k],delete = callback(v, from_k)
+      result[from_k], delete = callback(v, from_k)
       if delete then
         delete = from_k
       end
     else
-      return from_k,result
+      return from_k, result
     end
   end
 

--- a/table.lua
+++ b/table.lua
@@ -1,4 +1,4 @@
---- Functions for working with tables.
+--- Functions for working with arrays and tables.
 -- @module table
 -- @alias flib_table
 -- @usage local table = require('__flib__.table')
@@ -9,21 +9,80 @@ for name, func in pairs(table) do
   flib_table[name] = func
 end
 
---- Run `body(value, key)` over `n` items from `tbl`, starting after `from_k`.
+--- Recursively copy the contents of a table into a new table.
 --
--- The first return value of each invocation of `body` will be collected and returned in a table keyed by the current item's key.
+-- Does not create new copies of Factorio objects.
+-- @tparam table tbl The table to make a copy of.
+-- @treturn table The copied table.
+function flib_table.deep_copy(tbl)
+  local lookup_table = {}
+  local function _copy(object)
+    if type(object) ~= "table" then
+      return object
+    -- don't copy factorio rich objects
+    elseif object.__self then
+      return object
+    elseif lookup_table[object] then
+      return lookup_table[object]
+    end
+
+    local new_table = {}
+    lookup_table[object] = new_table
+    for index, value in pairs(object) do
+      new_table[_copy(index)] = _copy(value)
+    end
+
+    return setmetatable(new_table, getmetatable(object))
+  end
+  return _copy(tbl)
+end
+
+--- Recursively merge two or more tables.
+--
+-- Values from earlier tables are overwritten by values from later tables, unless both values are tables, in which case
+-- they are recursively merged.
+--
+-- Non-merged tables are deep-copied, so the result is brand-new.
+-- @tparam array tables An array of tables to merge.
+-- @treturn table The merged tables.
+function flib_table.deep_merge(tables)
+  local output = {}
+  for _, tbl in ipairs(tables) do
+    for k, v in pairs(tbl) do
+      if (type(v) == "table") then
+        if (type(output[k] or false) == "table") then
+          output[k] = flib_table.merge{output[k], v}
+        else
+          output[k] = table.deepcopy(v)
+        end
+      else
+        output[k] = v
+      end
+    end
+  end
+  return output
+end
+
+--- Iterate over a set number of items in a table, returning the next starting key and the results of `body`.
+--
+-- Runs `body(value, key)` over `n` items from `tbl`, starting after `from_k`.
+--
+-- The first return value of each invocation of `body` will be collected and returned in a table keyed by the current
+-- item's key.
 --
 -- The second return value of `body` is a flag requesting deletion of the current item.
 --
 -- **DO NOT** delete entires from `tbl` from within `body`, this will break the iteration.
 ---@tparam table tbl The table to iterate over.
----@tparam any|nil from_k The key to start iteration at, or `nil` to start at the beginning of `tbl`. If the key does not exist in `tbl`, it will be treated as `nil`.
+---@tparam any|nil from_k The key to start iteration at, or `nil` to start at the beginning of `tbl`. If the key does
+-- not exist in `tbl`, it will be treated as `nil`.
 ---@tparam uint n The number of items to iterate.
 ---@tparam function body Callback that will be run for each element in `tbl`.
 ---@tparam[opt] function _next A custom `next()` function. If not provided, the default `next()` will be used.
----@treturn any|nil Where the iteration ended. Can be any valid table key, or `nil` if the end of `tbl` was reached. Pass this as `from_k` in the next call to `for_n_of` for `tbl`.
+---@treturn any|nil Where the iteration ended. Can be any valid table key, or `nil` if the end of `tbl` was reached.
+-- Pass this as `from_k` in the next call to `for_n_of` for `tbl`.
 ---@treturn table The results compiled from the first return of `body`.
-function table.for_n_of(tbl, from_k, n, body, _next)
+function flib_table.for_n_of(tbl, from_k, n, body, _next)
   -- allow non-default `next` function
   -- use `next` if unspecified
   if not _next then _next = next end
@@ -62,6 +121,54 @@ function table.for_n_of(tbl, from_k, n, body, _next)
     from_k = prev
   end
   return from_k, result
+end
+
+--- Filter a table based on the result of a filter function.
+--
+-- Calls `filter(value, key)` on each element in the table, returning a new table with only pairs for which
+-- `filter` returned a truthy value.
+-- @tparam table tbl
+-- @tparam function filter Takes in `value` and `key` as parameters.
+-- @treturn table A new table containing only the filtered values.
+function flib_table.filter(tbl, filter)
+  local output = {}
+  for k, v in pairs(tbl) do
+    if filter(v, k) then
+      output[k] = v
+    end
+  end
+  return output
+end
+
+--- Create a transformed table using the output of a mapper function.
+--
+-- Calls `mapper(value, key)` on each element in the table, using the return as the new value for the key.
+-- @tparam table tbl
+-- @tparam function mapper Takes in `value` and `key` as parameters.
+-- @treturn table A new table containing the transformed values.
+function flib_table.map(tbl, mapper)
+  local output = {}
+  for k, v in pairs(tbl) do
+    output[k] = mapper(v, k)
+  end
+  return output
+end
+
+--- "Reduce" an array's values into a single output value, using the results of a reducer function.
+--
+-- Calls `reducer(accumulator, value, index)` on each element in the array, returning a single accumulated output value.
+-- @tparam array arr
+-- @tparam function reducer
+-- @tparam[opt] any initial_value The initial value for the accumulator. If not provided or is falsy, the first value in
+-- the array will be used as the initial `accumulator` value and skipped as `index`. Calling `reduce()` on an empty
+-- array without an `initial_value` will cause a crash.
+-- @treturn any The accumulated value.
+function flib_table.reduce(arr, reducer, initial_value)
+  local accumulator = initial_value or arr[1]
+  for i = (initial_value and 1 or 2), #arr do
+    accumulator = reducer(accumulator, arr[i], i)
+  end
+  return accumulator
 end
 
 return flib_table

--- a/table.lua
+++ b/table.lua
@@ -1,0 +1,67 @@
+--- Functions for working with tables.
+-- @module table
+-- @alias flib_table
+-- @usage local table = require('__flib__.table')
+local flib_table = {}
+
+-- import lua table functions
+for name, func in pairs(table) do
+  flib_table[name] = func
+end
+
+--- Run `body(value, key)` over `n` items from `tbl`, starting after `from_k`.
+--
+-- The first return value of each invocation of `body` will be collected and returned in a table keyed by the current item's key.
+--
+-- The second return value of `body` is a flag requesting deletion of the current item.
+--
+-- **DO NOT** delete entires from `tbl` from within `body`, this will break the iteration.
+---@tparam table tbl The table to iterate over.
+---@tparam any|nil from_k The key to start iteration at, or `nil` to start at the beginning of `tbl`. If the key does not exist in `tbl`, it will be treated as `nil`.
+---@tparam uint n The number of items to iterate.
+---@tparam function body Callback that will be run for each element in `tbl`.
+---@tparam[opt] function _next A custom `next()` function. If not provided, the default `next()` will be used.
+---@treturn any|nil Where the iteration ended. Can be any valid table key, or `nil` if the end of `tbl` was reached. Pass this as `from_k` in the next call to `for_n_of` for `tbl`.
+---@treturn table The results compiled from the first return of `body`.
+function table.for_n_of(tbl, from_k, n, body, _next)
+  -- allow non-default `next` function
+  -- use `next` if unspecified
+  if not _next then _next = next end
+
+  -- verify start key exists, else start from scratch
+  if from_k and not tbl[from_k] then
+    from_k = nil
+  end
+  local delete
+  local prev
+  local result = {}
+
+  -- run `n` times
+  for _ = 1, n, 1 do
+    local v
+    if not delete then
+      prev = from_k
+    end
+    from_k, v = _next(tbl, from_k)
+    if delete then
+      tbl[delete] = nil
+    end
+
+    if v then
+      result[from_k],delete = body(v, from_k)
+      if delete then
+        delete = from_k
+      end
+    else
+      return from_k,result
+    end
+  end
+
+  if delete then
+    tbl[delete] = nil
+    from_k = prev
+  end
+  return from_k, result
+end
+
+return flib_table

--- a/translation.lua
+++ b/translation.lua
@@ -4,14 +4,7 @@
 -- @usage local translation = require("__flib__.translation")
 local flib_translation = {}
 
--- TODO implement this in the table module
-local function shallow_copy(tbl)
-  local new_tbl = {}
-  for k, v in pairs(tbl) do
-    new_tbl[k] = v
-  end
-  return new_tbl
-end
+local table = require("__flib__.table")
 
 local math = math
 local next = next
@@ -166,7 +159,7 @@ function flib_translation.add_requests(player_index, strings)
       player_table.sort.next_index = 1
     else
       player_table.sort = {
-        strings = shallow_copy(strings),
+        strings = table.shallow_copy(strings),
         next_index = 1
       }
     end
@@ -176,7 +169,7 @@ function flib_translation.add_requests(player_index, strings)
       state = "sort",
       -- sort
       sort = {
-        strings = shallow_copy(strings),
+        strings = table.shallow_copy(strings),
         next_index = 1
       },
       -- translate


### PR DESCRIPTION
What it says on the tin. The table module is fairly straightforward, in that it contains several table functions. It imports the Lua table object into itself so mods can overwrite the default `table` global with the module and still be able to access everything.

Some functions were borrowed from the core lualib and modified for style and consistency, while some other functions were borrowed from (or loosely inspired by) stdlib's table module. I tried to strike a good balance between module size and utility, and I feel that I found that balance.

The only really _new_ thing here is JARG's `for_n_of` function, which greatly eases spreading iteration of a table over multiple ticks. I think it is quite useful and is quite a good thing to have.

I'll merge this in a day or two if nobody brings up anything specific.

All functions were tested in my sandbox mod, but the tests are pretty naive. I want to try to write a test helper at some point, but for now, this will do.

I still need to add usage examples for each function.

<details><summary>TEST CODE</summary>
<p>

```lua
local event = require("__flib__.event")
local table = require("__flib__.table")

event.on_init(function()
  local arr = {10, 20, 30, 40, 50, 60, 70, 80, 90}

  local tbl = {
    foo = "bar",
    bar = 69,
    baz = {
      foo2 = true,
      alf = nil
    }
  }

  local tbl2 = table.deep_copy(tbl)

  local equal = table.deep_compare(tbl, tbl2)

  local merged = table.deep_merge{tbl, {
    alf = {1, 3, 5, 7, 9},
    baz = {
      alf = false
    }
  }}

  table.for_each(arr, function(v)
    if v > 50 then
      return true
    else
      log(v)
    end
  end)

  local next_k = arr[1]
  local i = 0
  while next_k do
    i = i + 1
    log("ITERATION "..i)
    next_k = table.for_n_of(arr, next_k, 2, function(v)
      log(v)
    end)
  end

  local function filter_func(v)
    return (v / 10) % 2 == 0
  end

  local filtered = table.filter(arr, filter_func)
  local arr_filtered = table.filter(arr, filter_func, true)

  local inverted = table.invert(arr)

  local mapped = table.map(arr, function(v)
    return v * 2
  end)

  local sum = table.reduce(arr, function(acc, v) return acc + v end)
  local sum_minus_ten = table.reduce(arr, function(acc, v) return acc + v end, -10)

  local shallow_copy = table.shallow_copy(arr)
  local shallow_copy_rawset = table.shallow_copy(arr, true)

  local table_size = table.size(arr)

  local sliced = table.slice(arr, 3, 7) -- should be {30, 40, 50, 60, 70}
  local spliced = table.splice(arr, 1, 4) -- should be {10, 20, 30, 40}

  local breakpoint
end)
```

</p>
</details>