### PR TITLE
Add a misc function to intelligently split a string

### DIFF
--- a/misc.lua
+++ b/misc.lua
@@ -58,9 +58,7 @@ end
 function flib_misc.split_string(string, separator)
   local split_string = {}
   for token in string.gmatch(string, "[^" .. separator .. "]+") do
-    local number_token = tonumber(token)
-    token = number_token or token
-    table.insert(split_string, token)
+    table.insert(split_string, (tonumber(token) or token))
   end
   return split_string
 end

--- a/misc.lua
+++ b/misc.lua
@@ -51,4 +51,18 @@ function flib_misc.ticks_to_timestring(tick)
   end
 end
 
+--- Splits the given string, converting the results to the number-type if applicable
+-- @tparam string string The string to split
+-- @tparam string separator The separator to split along
+-- @treturn table The array containing the resulting substrings
+function flib_misc.split_string(string, separator)
+  local split_string = {}
+  for token in string.gmatch(string, "[^" .. separator .. "]+") do
+    local number_token = tonumber(token)
+    token = number_token or token
+    table.insert(split_string, token)
+  end
+  return split_string
+end
+
 return flib_misc


### PR DESCRIPTION
This adds a small misc function to split a string. It works the same as the one in the vanilla lualib, except it also converts any numeric substrings to be of type `number`, using `tonumber()`. This is much more convenient to use when some of your substrings are numbers, like numeric ID's or a part of a version string, for example.

If there's anything wrong with this submission, please let me know. I've not submitted code to any real project before, so I might be doing stuff incorrectly here.