### PR TITLE
Add naked scroll pane without inner padding

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -55,3 +55,7 @@ A marginless scroll pane for use inside of content panes. When activated, it dra
 **flib_naked_scroll_pane_under_tabs**
 
 Identical to `flib_naked_scroll_pane`, but has an inset on the top side when activated. Designed for use inside of a `tabbed_pane_with_no_side_padding` when not using a toolbar.
+
+**flib_naked_scroll_pane_no_padding**
+
+Identical to `flib_naked_scroll_pane`, but has no padding for the content that's put inside. Useful for wrapping a table in a scroll pane, for example.

--- a/prototypes/styles.lua
+++ b/prototypes/styles.lua
@@ -195,3 +195,13 @@ styles.flib_naked_scroll_pane_under_tabs = {
     shadow = default_inner_shadow
   }
 }
+
+styles.flib_naked_scroll_pane_no_padding = {
+  type = "scroll_pane_style",
+  extra_padding_when_activated = 0,
+  padding = 0,
+  vertically_stretchable = "on",
+  graphical_set = {
+    shadow = default_inner_shadow
+  }
+}

--- a/prototypes/styles.lua
+++ b/prototypes/styles.lua
@@ -200,7 +200,6 @@ styles.flib_naked_scroll_pane_no_padding = {
   type = "scroll_pane_style",
   extra_padding_when_activated = 0,
   padding = 0,
-  vertically_stretchable = "on",
   graphical_set = {
     shadow = default_inner_shadow
   }


### PR DESCRIPTION
I added a further scroll pane style, which is identical to `flib_naked_scroll_pane`, but without the inner padding. This is useful when trying to add a scroll pane around a table for example, as seen [here](https://i.imgur.com/75mXZNl.png).

As a sidenote, I also included `vertically_stretchable = "on"` as that is present on the `naked_scroll_pane`, but I'm not sure why. It automatically stretches to size 0 if you don't set a size on its parent I'm pretty sure, which is annoying of course. I brought it up with Raiguard, we'll see what becomes of that.

(Also typo in the commit message, my bad)