### PR TITLE
Fix crash in serialise_localised_string

### DIFF
--- a/translation.lua
+++ b/translation.lua
@@ -219,16 +219,24 @@ end
 -- @tparam Concepts.LocalisedString localised_string
 -- @treturn string The serialised @{Concepts.LocalisedString}.
 function flib_translation.serialise_localised_string(localised_string)
-  local output = "{"
   if type(localised_string) == "string" then return localised_string end
+  local output = "{"
+  local first = true
   for _, v in pairs(localised_string) do
-    if type(v) == "table" then
-      output = output..flib_translation.serialise_localised_string(v)
-    else
-      output = output.."\""..v.."\", "
+    if not first then
+      output = output..","
     end
+    local t = type(v)
+    if t == "table" then
+      output = output..flib_translation.serialise_localised_string(v)
+    elseif t == "string" then
+      output = output.."\""..v.."\""
+    else
+      output = output..tostring(v)
+    end
+    first = false
   end
-  output = string.gsub(output, ", $", "").."}"
+  output = output.."}"
   return output
 end
 

--- a/translation.lua
+++ b/translation.lua
@@ -226,13 +226,10 @@ function flib_translation.serialise_localised_string(localised_string)
     if not first then
       output = output..","
     end
-    local t = type(v)
-    if t == "table" then
+    if type(v) == "table" then
       output = output..flib_translation.serialise_localised_string(v)
-    elseif t == "string" then
-      output = output.."\""..v.."\""
     else
-      output = output..tostring(v)
+      output = output.."\""..tostring(v).."\""
     end
     first = false
   end


### PR DESCRIPTION
`serialise_localised_string` was assuming that non-table values of a `LocalisedString` were always strings, which is not true. Other primitive values are also allowed as arguments to localised strings. I also improved the comma-separator logic to not use `gsub`.