### PR TITLE
gui-beta optimization

### DIFF
--- a/gui-beta.lua
+++ b/gui-beta.lua
@@ -90,15 +90,21 @@ local function recursive_build(parent, structure, refs)
   -- create element
   local elem = parent.add(structure)
 
-  if structure.style_mods then
-    for k, v in pairs(structure.style_mods) do
-      elem.style[k] = v
+  do
+    local style_mods = structure.style_mods
+    if style_mods then
+      for k, v in pairs(style_mods) do
+        elem.style[k] = v
+      end
     end
   end
 
-  if structure.elem_mods then
-    for k, v in pairs(structure.elem_mods) do
-      elem[k] = v
+  do
+    local elem_mods = structure.elem_mods
+    if elem_mods then
+      for k, v in pairs(elem_mods) do
+        elem[k] = v
+      end
     end
   end
 
@@ -128,11 +134,12 @@ local function recursive_build(parent, structure, refs)
   end
 
   if tabs then
+    local add_tab = elem.add_tab
     for i = 1, #tabs do
       local tab_and_content = tabs[i]
       local tab = recursive_build(elem, tab_and_content.tab, refs)
       local content = recursive_build(elem, tab_and_content.content, refs)
-      elem.add_tab(tab, content)
+      add_tab(tab, content)
     end
   end
 

--- a/gui-beta.lua
+++ b/gui-beta.lua
@@ -70,13 +70,13 @@ end
 -- navigate a structure to build a GUI
 local function recursive_build(parent, structure, refs)
   -- prepare tags
-  do
-    local tags = structure.tags or {}
-    tags.flib = structure.actions
-    structure.tags = {
-      [mod_name] = tags
-    }
-  end
+  local tags = structure.tags or {}
+  local actions = structure.actions
+  local tags_flib = tags.flib
+  tags.flib = actions
+  structure.tags = {
+    [mod_name] = tags
+  }
 
   -- local these for later
   local tabs = structure.tabs
@@ -89,6 +89,12 @@ local function recursive_build(parent, structure, refs)
 
   -- create element
   local elem = parent.add(structure)
+
+  -- restore structure
+  structure.tags = tabs
+  structure.children = children
+  structure.actions = actions
+  tags.flib = tags_flib
 
   do
     local style_mods = structure.style_mods

--- a/gui-beta.lua
+++ b/gui-beta.lua
@@ -61,10 +61,26 @@ end
 
 -- navigate a structure to build a GUI
 local function recursive_build(parent, structure, refs)
+  -- prepare tags
+  do
+    local tags = structure.tags or {}
+    tags.flib = structure.actions
+    structure.tags = {
+      [script.mod_name] = tags
+    }
+  end
+
+  -- local these for later
+  local tabs = structure.tabs
+  local children = structure.children
+
+  -- make the game not convert these into a property tree for no reason
+  structure.tabs = nil
+  structure.children = nil
+  structure.actions = nil
+
   -- create element
   local elem = parent.add(structure)
-  -- reset tags so they can be added back in later with a subtable
-  elem.tags = {}
 
   if structure.style_mods then
     for k, v in pairs(structure.style_mods) do
@@ -76,14 +92,6 @@ local function recursive_build(parent, structure, refs)
     for k, v in pairs(structure.elem_mods) do
       elem[k] = v
     end
-  end
-
-  if structure.tags then
-    flib_gui.set_tags(elem, structure.tags)
-  end
-
-  if structure.actions then
-    flib_gui.update_tags(elem, {flib = structure.actions})
   end
 
   if structure.ref then
@@ -104,14 +112,12 @@ local function recursive_build(parent, structure, refs)
     prev[prev_key] = elem
   end
 
-  local children = structure.children
   if children then
     for i = 1, #children do
       recursive_build(elem, children[i], refs)
     end
   end
 
-  local tabs = structure.tabs
   if tabs then
     for i = 1, #tabs do
       local tab_and_content = tabs[i]

--- a/gui-beta.lua
+++ b/gui-beta.lua
@@ -102,22 +102,23 @@ local function recursive_build(parent, structure, refs)
     end
   end
 
-  if structure.ref then
-    -- recursively create tables as needed
-    local prev = refs
-    local prev_key
-    local nav
-    for _, key in pairs(structure.ref) do
-      prev = prev_key and prev[prev_key] or prev
-      nav = prev[key]
-      if nav then
-        prev = nav
-      else
-        prev[key] = {}
-        prev_key = key
+  do
+    local ref = structure.ref
+    if ref then
+      -- recursively create tables as needed
+      local prev = refs
+      local ref_length = #ref
+      for i = 1, ref_length - 1 do
+        local current_key = ref[i]
+        local current = prev[current_key]
+        if not current then
+          current = {}
+          prev[current_key] = current
+        end
+        prev = current
       end
+      prev[ref[ref_length]] = elem
     end
-    prev[prev_key] = elem
   end
 
   if children then


### PR DESCRIPTION
Some improvements to gui-beta gui building.
The major one is the first commit `Prepare gui structure before adding to parent`.
The other 3 commits are optional, you can cherry pick whatever you want out of those.
I think `Improve gui refs building` is generally a good one and the other ones depend on preference. They all don't make a huge difference.

As mentioned on discord, the reason this is so much faster (10-30% depending on the tests i did) is because the game doesn't have to convert the entire children tree into a property tree when adding all the elements. Additionally the tags are prepared before the `add` call instead of afterwards, sometimes even with 2 more reads of the tags and 2 more writes, which is a lot of table building and parsing for no reason other than reusing functions that already exist, but in the first commit you can see that it's a very tiny amount of "code duplication", if you can even call it that.