### PR TITLE
Make create_icons use all of the icon specifications.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ Date: 2021-02-12
     - Significant performance improvements to `gui-beta.build()`
   Bugfixes:
     - Fixed `math.max_uint` being one number too large
+    - Fixed `data-util.create_icons()` not using all of the icon specifications
 ---------------------------------------------------------------------------------------------------
 Version: 0.6.1
 Date: 2021-01-02

--- a/data-util.lua
+++ b/data-util.lua
@@ -58,9 +58,15 @@ function flib_data_util.create_icons(prototype, new_layers)
   if prototype.icons then
     local icons ={}
     for _, v in pairs(prototype.icons) do
-      local sub_icon = table.deepcopy(v)
-      sub_icon.icon_size = v.icon_size or prototype.icon_size
-      icons[#icons+1] = sub_icon
+      -- assume every other mod is lacking full prototype definitions
+      icons[#icons+1] = {
+        icon = v.icon,
+        icon_size = v.icon_size or prototype.icon_size or 32,
+        icon_mipmaps = v.icon_mipmaps or 0
+        tint = v.tint,
+        scale = v.scale,
+        shift = v.shift,
+      }
     end
     if new_layers then
       for _, new_layer in pairs(new_layers) do

--- a/data-util.lua
+++ b/data-util.lua
@@ -62,7 +62,7 @@ function flib_data_util.create_icons(prototype, new_layers)
       icons[#icons+1] = {
         icon = v.icon,
         icon_size = v.icon_size or prototype.icon_size or 32,
-        icon_mipmaps = v.icon_mipmaps or 0,
+        icon_mipmaps = v.icon_mipmaps or prototype.icon_mipmaps or 0,
         tint = v.tint,
         scale = v.scale,
         shift = v.shift,

--- a/data-util.lua
+++ b/data-util.lua
@@ -58,13 +58,13 @@ function flib_data_util.create_icons(prototype, new_layers)
   if prototype.icons then
     local icons ={}
     for _, v in pairs(prototype.icons) do
-      -- assume every other mod is lacking full prototype definitions
+      -- over define as much as possible to minimize weirdness: https://forums.factorio.com/viewtopic.php?f=25&t=81980
       icons[#icons+1] = {
         icon = v.icon,
         icon_size = v.icon_size or prototype.icon_size or 32,
         icon_mipmaps = v.icon_mipmaps or prototype.icon_mipmaps or 0,
         tint = v.tint,
-        scale = v.scale,
+        scale = v.scale or 1,
         shift = v.shift,
       }
     end

--- a/data-util.lua
+++ b/data-util.lua
@@ -58,12 +58,9 @@ function flib_data_util.create_icons(prototype, new_layers)
   if prototype.icons then
     local icons ={}
     for _, v in pairs(prototype.icons) do
-      -- assume every other mod is lacking full prototype definitions
-      icons[#icons+1] = {
-        icon = v.icon,
-        icon_size = v.icon_size or prototype.icon_size or 32,
-        tint = v.tint
-      }
+      local sub_icon = table.deepcopy(v)
+      sub_icon.icon_size = v.icon_size or prototype.icon_size
+      icons[#icons+1] = sub_icon
     end
     if new_layers then
       for _, new_layer in pairs(new_layers) do

--- a/data-util.lua
+++ b/data-util.lua
@@ -62,7 +62,7 @@ function flib_data_util.create_icons(prototype, new_layers)
       icons[#icons+1] = {
         icon = v.icon,
         icon_size = v.icon_size or prototype.icon_size or 32,
-        icon_mipmaps = v.icon_mipmaps or 0
+        icon_mipmaps = v.icon_mipmaps or 0,
         tint = v.tint,
         scale = v.scale,
         shift = v.shift,


### PR DESCRIPTION
`data-util.create_icons()` did not copy all specifications from the `prototype.icons` table.

The bug resulted in the following icons:
![before](https://user-images.githubusercontent.com/4164107/110131704-bb0d2a00-7dca-11eb-9bf3-fcaaff9d0770.png)

The new code will produce the following icons:
![after](https://user-images.githubusercontent.com/4164107/110131799-d4ae7180-7dca-11eb-9786-7771f0393ae6.png)

The following mods where used for the screenshots:
  * angelsaddons-mobility_0.0.6
  * flib_0.7.1
  * LogisticTrainNetwork_1.15.4