### PR TITLE
Dictionary: fix modules with hyphens in thier names

### DIFF
--- a/dictionary.lua
+++ b/dictionary.lua
@@ -210,7 +210,13 @@ function flib_dictionary.check_skipped()
   end
 end
 
-local dictionary_match_string = kv("^FLIB_DICTIONARY_MOD", script.mod_name)
+
+--- Escape match special characters
+local function match_literal(s)
+    return string.gsub(s, "%-", "%%-")
+end
+
+local dictionary_match_string = kv("^FLIB_DICTIONARY_MOD", match_literal(script.mod_name))
   ..kv("FLIB_DICTIONARY_NAME", "(.-)")
   ..kv("FLIB_DICTIONARY_LANGUAGE", "(.-)")
   ..kv("FLIB_DICTIONARY_STRING_INDEX", "(%d-)")


### PR DESCRIPTION
It's legal to name a mod something like 'my-amazing-train-mod'.

Translations were not being recognised for these as the '-' is a
metacharacter.

There's porbably a more elegant fix for this, but this got the module I was working on moving
