### PR TITLE
Fix off-by-one in math.sum

### DIFF
--- a/math.lua
+++ b/math.lua
@@ -131,7 +131,7 @@ end
 --- @param set number[]
 --- @return number
 function flib_math.sum(set)
-  local sum = set[2] or 0
+  local sum = set[1] or 0
   for i = 2, #set do
     sum = sum + set[i]
   end

--- a/tests/test_math.lua
+++ b/tests/test_math.lua
@@ -93,16 +93,16 @@ end
 
 function Test_sum()
   Test.assertEquals(math.sum(values1), 100)
-  Test.assertEquals(math.sum(values2), 185)
-  Test.assertEquals(math.sum(values3), -5)
-  Test.assertEquals(math.sum(values4), -117)
+  Test.assertEquals(math.sum(values2), 170)
+  Test.assertEquals(math.sum(values3), -20)
+  Test.assertEquals(math.sum(values4), -128)
 end
 
 function Test_mean()
   Test.assertEquals(math.mean(values1), 25)
-  Test.assertEquals(math.mean(values2), 37)
-  Test.assertEquals(math.mean(values3), -1)
-  Test.assertEquals(math.mean(values4), -23.4)
+  Test.assertEquals(math.mean(values2), 34)
+  Test.assertEquals(math.mean(values3), -4)
+  Test.assertEquals(math.mean(values4), -25.6)
 end
 
 function Test_midrange()


### PR DESCRIPTION
# Description

The original code struck me as odd, shouldn’t it be `sum = set[1] or 0`? Right now, it’s discarding the first element, and counts the second twice towards the sum.

The code was modified to `set[2]` on 2022-04-24 in 85686ae58eb07a73418e53392921663c6b35932d, before it was indeed `sum = set[1]`.

# Tests?

There _are_ tests in `tests/test_math.lua`, but they’re asserting wrong things,
```lua
local values1 = { 25, 25, 25, 25 }
Test.assertEquals(math.sum(values1), 100)
-- Right

local values2 = { 10, 25, 40, 45, 50 }
Test.assertEquals(math.sum(values2), 185)
-- 10+25+40+45+50 = 170

local values3 = { 10, 25, 40, -50, -45 }
Test.assertEquals(math.sum(values3), -5)
-- 10+25+40-50-45 = -20

local values4 = { -23, -12, -50, -10, -33 }
Test.assertEquals(math.sum(values4), -117)
-- -23-12-50-10-33 = -128
```

# CI?
I’m not on a computer with a Lua dev env at the moment, so unfortunately I can’t run the tests. I’d be open to adding CI support to the repo if it’s something you’d like o:-)