### PR TITLE
Actually use prototypes variable in `flib_prototypes.find`

### DIFF
--- a/prototypes.lua
+++ b/prototypes.lua
@@ -175,7 +175,7 @@ function flib_prototypes.find(base_type, name)
   for derived_type in pairs(defines.prototypes[base_type]) do
     local prototypes = data.raw[derived_type]
     if prototypes then
-      local prototype = data.raw[derived_type][name]
+      local prototype = prototypes[name]
       if prototype then
         return prototype
       end


### PR DESCRIPTION
Was glancing at this to make sure it was what I thought it was for borrowing a function that used it.
Noticed it was doing `data.raw[derived_type][name]` despite having already stored the derived_type table in a variable.

Couldn't help myself but to fix it.